### PR TITLE
adjust size and alignment of logo to reduce header's vertical size

### DIFF
--- a/static/logo-web.svg
+++ b/static/logo-web.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="210mm" height="297mm" version="1.1" viewBox="0 0 210 297" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="200mm" height="200mm" version="1.1" viewBox="5 5 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs>
   <linearGradient id="linearGradient2743" x1="400.35" x2="400" y1="715" y2="75" gradientUnits="userSpaceOnUse">
    <stop stop-color="#22014f" offset="0"/>

--- a/themes/middleware/assets/css/style.css
+++ b/themes/middleware/assets/css/style.css
@@ -318,6 +318,7 @@ pre {
 .navbar-brand img {
   max-width: 100px;
   margin-bottom: 0;
+  vertical-align: top;
 }
 
 .navbar .nav-item > .nav-link {


### PR DESCRIPTION
Avec cette simple astuce, .navbar perd du poid rapidement!

avant:
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/28787740/140546112-07497531-2162-4c38-84b3-c21a232a6e14.png">

après:
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/28787740/140546161-a8dbc508-3449-4c42-955b-2bc0f778f1fd.png">
