### PR TITLE
Prevent the sidebar from hiding behind the header

### DIFF
--- a/themes/middleware/assets/css/style.css
+++ b/themes/middleware/assets/css/style.css
@@ -207,14 +207,7 @@ select:focus {
 }
 
 .section-sm {
-  padding-top: 60px;
-  padding-bottom: 60px;
-}
-
-@media (max-width: 768px) {
-  .section-sm {
-    padding-top: 40px;
-  }
+  padding-top: 30px;
 }
 
 .section-title {
@@ -817,7 +810,7 @@ tbody {
 .sidebar{
   background-color: var(--white-color);
   position: sticky;
-  top: 50px;
+  top: 150px;
   margin-bottom: 30px;
   padding: 40px 10px 20px 10px;
 }


### PR DESCRIPTION
before:
<img width="977" alt="image" src="https://user-images.githubusercontent.com/28787740/145578973-955b8838-e460-41fa-8512-f05fd45aec6b.png">

after:
<img width="963" alt="image" src="https://user-images.githubusercontent.com/28787740/145578883-0b3912b0-0e65-4004-928a-db490e41427a.png">
