### PR TITLE
allow the side menu to scroll independently of the page

### DIFF
--- a/themes/middleware/assets/css/style.css
+++ b/themes/middleware/assets/css/style.css
@@ -825,6 +825,8 @@ tbody {
   position: sticky;
   top: 95px;
   padding: 60px 0;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
 }
 
 .list-styled li.active > a {


### PR DESCRIPTION
<img width="588" alt="Capture d’écran 2023-07-07 à 17 03 12" src="https://github.com/php-etl/documentation/assets/28787740/37bcd2bb-a353-42fb-9f05-7d49329e133a">
