### PR TITLE
Add copy's section to the core page of the documentation

### DIFF
--- a/content/core-concept/satellite/_index.en.md
+++ b/content/core-concept/satellite/_index.en.md
@@ -96,6 +96,42 @@ satellites:
 #...
 ```
 
+#### Copy custom files
+
+You want to use a class but you can't add a package to your composer ? Use the copy option under de docker/filesystem key.
+
+The build will copy files you indicate on the yaml to the path you provide. If you are a class with namespace, don't forget to add it to your autoload (see autoload section lower)
+
+```yaml
+version: '0.3'
+satellites:
+  my_satellite:
+    label: 'My first Satellite'
+    filesystem:
+      copy:
+        - from: '../Foo/Bar'
+          to: '../build/Foo/Bar'
+      path: ../build # path to the build directory, relative to the YAML file
+#...
+```
+
+```yaml
+version: '0.3'
+satellites:
+  my_satellite:
+    label: 'My first Satellite'
+    docker:
+      from: php:8.0-cli-alpine
+      workdir: /var/www/html
+      tags:
+        - acmeinc/my-satellite:latest
+        - acmeinc/my-satellite:1.0.0
+      copy:
+        - from: '../Foo/Bar'
+          to: './src/Foo/Bar'
+#...
+```
+
 ### Configure Composer
 
 It's possible to declare the Composer dependencies, autoloads, repositories and auths that our microservice needs with the `composer` key.

--- a/content/core-concept/satellite/_index.en.md
+++ b/content/core-concept/satellite/_index.en.md
@@ -96,11 +96,13 @@ satellites:
 #...
 ```
 
-#### Copy custom files
+#### Add custom code without a Composer package
 
-You want to use a class but you can't add a package to your composer ? Use the copy option under de docker/filesystem key.
+Sometimes you need to use a custom class but you can't add a composer package, or creating this package is a disproportional effort. In this cas you have the `copy` options under the adapter.
 
-The build will copy files you indicate on the yaml to the path you provide. If you are a class with namespace, don't forget to add it to your autoload (see autoload section lower)
+Supported by [Docker](#using-docker-) and [Filesystem](#using-the-file-system) adapters.
+
+The build will copy files you list. If you use a class with a namespace, you will need to add the namespace to the [autoloading](#autoload) specification.
 
 ```yaml
 version: '0.3'


### PR DESCRIPTION
fixes #63 

Linked to the https://github.com/php-etl/satellite/pull/150

![image](https://github.com/php-etl/documentation/assets/99172532/bbec1e44-3472-4059-bd9c-961116e10097)
